### PR TITLE
TDW fixed layout for swiped state

### DIFF
--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol SwipeActionsViewDelegate: class {
+protocol SwipeActionsViewDelegate: AnyObject {
     func swipeActionsView(_ swipeActionsView: SwipeActionsView, didSelect action: SwipeAction)
 }
 

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -137,16 +137,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     /// :nodoc:
     override open func layoutSubviews() {
         super.layoutSubviews()
-        if state.isActive {
-            switch state {
-            case .left:
-                swipeController.showSwipe(orientation: .left, animated: false)
-            case .right:
-                swipeController.showSwipe(orientation: .right, animated: false)
-            case .animatingToCenter, .center, .dragging:
-                break
-            }
-        }
+        swipeController.restoreActiveState()
     }
     
     // Override so we can accept touches anywhere within the cell's original frame.

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -133,6 +133,21 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
             reset()
         }
     }
+
+    /// :nodoc:
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        if state.isActive {
+            switch state {
+            case .left:
+                swipeController.showSwipe(orientation: .left, animated: false)
+            case .right:
+                swipeController.showSwipe(orientation: .right, animated: false)
+            case .animatingToCenter, .center, .dragging:
+                break
+            }
+        }
+    }
     
     // Override so we can accept touches anywhere within the cell's original frame.
     // This is required to detect touches on the `SwipeActionsView` sitting alongside the

--- a/Source/SwipeCollectionViewCellDelegate.swift
+++ b/Source/SwipeCollectionViewCellDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 /**
  The `SwipeCollectionViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the item is swiped.
  */
-public protocol SwipeCollectionViewCellDelegate: class {
+public protocol SwipeCollectionViewCellDelegate: AnyObject {
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified item.
      

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-protocol SwipeControllerDelegate: class {
+protocol SwipeControllerDelegate: AnyObject {
     
     func swipeController(_ controller: SwipeController, canBeginEditingSwipeableFor orientation: SwipeActionsOrientation) -> Bool
     

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -150,7 +150,9 @@ class SwipeController: NSObject {
             if swipeable.state.isActive == false && swipeable.bounds.midX == target.center.x  {
                 return
             }
-            
+
+            // velocity for final states is always 0. Changed to translation
+            let velocity = gesture.translation(in: target)
             swipeable.state = targetState(forVelocity: velocity)
             
             if actionsView.expanded == true, let expandedAction = actionsView.expandableAction  {

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -357,25 +357,8 @@ extension SwipeController: UIGestureRecognizerDelegate {
         if gestureRecognizer == panGestureRecognizer,
             let view = gestureRecognizer.view,
             let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
-            let translation = gestureRecognizer.velocity(in: view)
-            // Only consider swipes of less than 22.5° from horizontal
-            guard atan2(abs(translation.y), abs(translation.x)) < .pi / 8 else { return false }
-
-            let direction: SwipeActionsOrientation = translation.x < 0 ? .right : .left
-            let hasActions = (delegate?.swipeController(self, editActionsForSwipeableFor: direction)?.count ?? 0) > 0
-
-            switch (swipeable?.state ?? .center, direction, hasActions) {
-                // Allow: Swipe to reveal actions
-            case (.center, .left, true), (.center, .right, true): return true
-                // Allow: Unswipe visible actions
-            case (.right, .left, _), (.left, .right, _): return true
-                // Allow: Swipes in direction that's already revealed, may trigger default actions.
-            case (.left, .left, _), (.right, .right, _): return true
-
-                // Disallow: Swipes that reveal no actions
-            case (.center, _, false): return false
-            case (.dragging, _, _), (.animatingToCenter, _, _): return false
-            }
+            let translation = gestureRecognizer.translation(in: view)
+            return abs(translation.y) <= abs(translation.x)
         }
         
         return true

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -341,6 +341,19 @@ class SwipeController: NSObject {
         swipeable?.actionsView?.removeFromSuperview()
         swipeable?.actionsView = nil
     }
+
+    /// Restoring active swiped state after `layoutSubviews`.
+    func restoreActiveState() {
+        guard let state = swipeable?.state, state.isActive else { return }
+        switch state {
+        case .left:
+            showSwipe(orientation: .left, animated: false)
+        case .right:
+            showSwipe(orientation: .right, animated: false)
+        case .animatingToCenter, .center, .dragging:
+            break
+        }
+    }
     
 }
 

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -104,6 +104,21 @@ open class SwipeTableViewCell: UITableViewCell {
             }
         }
     }
+
+    /// :nodoc:
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        if state.isActive {
+            switch state {
+            case .left:
+                swipeController.showSwipe(orientation: .left, animated: false)
+            case .right:
+                swipeController.showSwipe(orientation: .right, animated: false)
+            case .animatingToCenter, .center, .dragging:
+                break
+            }
+        }
+    }
     
     /// :nodoc:
     override open func setEditing(_ editing: Bool, animated: Bool) {

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -108,16 +108,7 @@ open class SwipeTableViewCell: UITableViewCell {
     /// :nodoc:
     override open func layoutSubviews() {
         super.layoutSubviews()
-        if state.isActive {
-            switch state {
-            case .left:
-                swipeController.showSwipe(orientation: .left, animated: false)
-            case .right:
-                swipeController.showSwipe(orientation: .right, animated: false)
-            case .animatingToCenter, .center, .dragging:
-                break
-            }
-        }
+        swipeController.restoreActiveState()
     }
     
     /// :nodoc:

--- a/Source/SwipeTableViewCellDelegate.swift
+++ b/Source/SwipeTableViewCellDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 /**
  The `SwipeTableViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the cell is swiped.
  */
-public protocol SwipeTableViewCellDelegate: class {
+public protocol SwipeTableViewCellDelegate: AnyObject {
     
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified row.

--- a/Source/SwipeView.swift
+++ b/Source/SwipeView.swift
@@ -69,7 +69,7 @@ open class SwipeView: UIView {
         swipeController.delegate = self
     }
 
-    override open  func didMoveToWindow() {
+    override open func didMoveToWindow() {
         super.didMoveToWindow()
 
         var view: UIView = self
@@ -84,6 +84,21 @@ open class SwipeView: UIView {
                 swipeRecognizer.panGestureRecognizer.removeTarget(self, action: nil)
                 swipeRecognizer.panGestureRecognizer.addTarget(self, action: #selector(handlePan(gesture:)))
                 return
+            }
+        }
+    }
+
+    /// :nodoc:
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        if state.isActive {
+            switch state {
+            case .left:
+                swipeController.showSwipe(orientation: .left, animated: false)
+            case .right:
+                swipeController.showSwipe(orientation: .right, animated: false)
+            case .animatingToCenter, .center, .dragging:
+                break
             }
         }
     }

--- a/Source/SwipeView.swift
+++ b/Source/SwipeView.swift
@@ -91,16 +91,7 @@ open class SwipeView: UIView {
     /// :nodoc:
     override open func layoutSubviews() {
         super.layoutSubviews()
-        if state.isActive {
-            switch state {
-            case .left:
-                swipeController.showSwipe(orientation: .left, animated: false)
-            case .right:
-                swipeController.showSwipe(orientation: .right, animated: false)
-            case .animatingToCenter, .center, .dragging:
-                break
-            }
-        }
+        swipeController.restoreActiveState()
     }
 
     /// :nodoc:


### PR DESCRIPTION
Apply open source changes from `https://github.com/SwipeCellKit/SwipeCellKit/pull/ 381`

fixes:
- allow transition from swiped state to normal by swipe
- after layout subviews restoring swiped state